### PR TITLE
add missing error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 
 Enables plant uml rendering in markdown files.
 
+## Prerequisites
+
+A valid font has to be installed on the host machine for the rendering to work.
+
+> **Hint:** Our official Docker images already come with a preinstalled font.
+
 ## Build and testing
 
 The plugin can be compiled and packaged with the normal maven lifecycle:

--- a/src/main/java/com/cloudogu/plantuml/PlantUMLDecodeException.java
+++ b/src/main/java/com/cloudogu/plantuml/PlantUMLDecodeException.java
@@ -24,22 +24,19 @@
 
 package com.cloudogu.plantuml;
 
-import sonia.scm.ExceptionWithContext;
-
-import java.util.Optional;
+import sonia.scm.BadRequestException;
 
 import static sonia.scm.ContextEntry.ContextBuilder.entity;
 
 @SuppressWarnings("java:S110") // many parent are kind of normal for exceptions
-public class PlantUMLRenderException extends ExceptionWithContext {
+public class PlantUMLDecodeException extends BadRequestException {
 
-  private static final String CODE = "7sSM9vTMp1";
-  private static final String URL = "https://scm-manager.org/plugins/scm-markdown-plantuml-plugin/";
+  private static final String CODE = "6ISMX03n61";
 
-  PlantUMLRenderException(Exception cause) {
+  PlantUMLDecodeException(Exception cause) {
     super(
       entity("Format", "svg").in("Image", "PlantUML").build(),
-      "error rendering plant uml",
+      "Failed to decode plantuml",
       cause
     );
   }
@@ -47,10 +44,5 @@ public class PlantUMLRenderException extends ExceptionWithContext {
   @Override
   public String getCode() {
     return CODE;
-  }
-
-  @Override
-  public Optional<String> getUrl() {
-    return Optional.of(URL);
   }
 }

--- a/src/main/java/com/cloudogu/plantuml/PlantUMLRenderException.java
+++ b/src/main/java/com/cloudogu/plantuml/PlantUMLRenderException.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.cloudogu.plantuml;
 
 import sonia.scm.ContextEntry;
@@ -9,8 +32,8 @@ public class PlantUMLRenderException extends ExceptionWithContext {
 
   private static final String CODE = "7sSM9vTMp1";
 
-  public PlantUMLRenderException() {
-      super(ContextEntry.ContextBuilder.entity("Format", "svg").in("Image", "PlantUML").build(), "error rendering plant uml");
+  public PlantUMLRenderException(Exception cause) {
+      super(ContextEntry.ContextBuilder.entity("Format", "svg").in("Image", "PlantUML").build(), "error rendering plant uml", cause);
   }
 
   @Override

--- a/src/main/java/com/cloudogu/plantuml/PlantUMLRenderException.java
+++ b/src/main/java/com/cloudogu/plantuml/PlantUMLRenderException.java
@@ -1,0 +1,18 @@
+package com.cloudogu.plantuml;
+
+import sonia.scm.ContextEntry;
+import sonia.scm.ExceptionWithContext;
+
+public class PlantUMLRenderException extends ExceptionWithContext {
+
+  private static final String CODE = "7sSM9vTMp1";
+
+  public PlantUMLRenderException() {
+      super(ContextEntry.ContextBuilder.entity("Format", "svg").in("Image", "PlantUML").build(), "error rendering plant uml");
+  }
+
+  @Override
+  public String getCode() {
+    return CODE;
+  }
+}

--- a/src/main/java/com/cloudogu/plantuml/PlantUMLRenderException.java
+++ b/src/main/java/com/cloudogu/plantuml/PlantUMLRenderException.java
@@ -3,6 +3,8 @@ package com.cloudogu.plantuml;
 import sonia.scm.ContextEntry;
 import sonia.scm.ExceptionWithContext;
 
+import java.util.Optional;
+
 public class PlantUMLRenderException extends ExceptionWithContext {
 
   private static final String CODE = "7sSM9vTMp1";
@@ -14,5 +16,10 @@ public class PlantUMLRenderException extends ExceptionWithContext {
   @Override
   public String getCode() {
     return CODE;
+  }
+
+  @Override
+  public Optional<String> getUrl() {
+    return Optional.of("https://scm-manager.org/plugins/scm-markdown-plantuml-plugin/");
   }
 }

--- a/src/main/java/com/cloudogu/plantuml/PlantUmlResource.java
+++ b/src/main/java/com/cloudogu/plantuml/PlantUmlResource.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package com.cloudogu.plantuml;
 
 import net.sourceforge.plantuml.FileFormat;
@@ -37,7 +36,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
 
 @AllowAnonymousAccess
@@ -57,7 +55,7 @@ public class PlantUmlResource {
       final StreamingOutput streamingOutput = outputStream -> reader.generateImage(outputStream, new FileFormatOption(FileFormat.SVG));
       return Response.ok(streamingOutput).lastModified(new Date()).header("Cache-Control", "public, max-age=31536000").build();
     } catch (Exception e) {
-      throw new PlantUMLRenderException();
+      throw new PlantUMLRenderException(e);
     }
   }
 

--- a/src/main/java/com/cloudogu/plantuml/PlantUmlResource.java
+++ b/src/main/java/com/cloudogu/plantuml/PlantUmlResource.java
@@ -37,6 +37,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
 
 @AllowAnonymousAccess
@@ -51,9 +52,13 @@ public class PlantUmlResource {
     final TranscoderSmart transcoder = new TranscoderSmart();
     final String decode = transcoder.decode(encodedContent);
 
-    SourceStringReader reader = new SourceStringReader(decode);
-    final StreamingOutput streamingOutput = outputStream -> reader.generateImage(outputStream, new FileFormatOption(FileFormat.SVG));
-    return Response.ok(streamingOutput).lastModified(new Date()).header("Cache-Control", "public, max-age=31536000").build();
+    try {
+      SourceStringReader reader = new SourceStringReader(decode);
+      final StreamingOutput streamingOutput = outputStream -> reader.generateImage(outputStream, new FileFormatOption(FileFormat.SVG));
+      return Response.ok(streamingOutput).lastModified(new Date()).header("Cache-Control", "public, max-age=31536000").build();
+    } catch (Exception e) {
+      throw new PlantUMLRenderException();
+    }
   }
 
 }

--- a/src/main/js/index.tsx
+++ b/src/main/js/index.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-import {binder} from "@scm-manager/ui-extensions";
+import { binder } from "@scm-manager/ui-extensions";
 import PlantUmlRenderer from "./PlantUmlRenderer";
 
 binder.bind("markdown-renderer.code.uml", PlantUmlRenderer);

--- a/src/main/resources/locales/de/plugins.json
+++ b/src/main/resources/locales/de/plugins.json
@@ -1,5 +1,11 @@
 {
   "scm-markdown-plantuml-plugin": {
-
+    "error": "Plant UML Diagramm konnte nicht geladen werden"
+  },
+  "errors": {
+    "7sSM9vTMp1": {
+      "displayName": "Plant UML Renderfehler",
+      "description": "Der Server konnte das beschriebene Diagramm nicht rendern. Es könnte sein, dass keine Fonts auf dem Server installiert sind."
+    }
   }
 }

--- a/src/main/resources/locales/en/plugins.json
+++ b/src/main/resources/locales/en/plugins.json
@@ -1,5 +1,11 @@
 {
   "scm-markdown-plantuml-plugin": {
-
+    "error": "Plant UML diagram could not be loaded"
+  },
+  "errors": {
+    "7sSM9vTMp1": {
+      "displayName": "Plant UML Render Error",
+      "description": "The server could not render the described diagram. It is possible that no fonts are installed on the server."
+    }
   }
 }


### PR DESCRIPTION
## Proposed changes

The original implementation was missing proper error handling and display in the frontend. Because the `onerror` handler of the img html element doesnt provide the original exception, the image is now loaded through an xhr request and then transformed into a dataurl.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [ ] CHANGELOG.md updated
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
